### PR TITLE
Update DEFAULT_ARGS to replace deprecated value with current supported value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+2.2.1
+---
+
+- Update `DEFAULT_ARGS` to use `autocorrect` instead of `auto-correct` matching the naming of the argument in the current version of rubocop (as of 1.30.0).
 
 master
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 2.2.1
 ---
 
-- Update `DEFAULT_ARGS` to use `autocorrect` instead of `auto-correct` matching the naming of the argument in the current version of rubocop (as of 1.30.0).
+- Update `DEFAULT_ARGS` to use `-a` instead of `--auto-correct` to address the change of the argument name in newer versions of rubocop (1.30.0 and newer) while still supporting older versions of rubocop.
 
 master
 ---

--- a/lib/rubocop_runner.rb
+++ b/lib/rubocop_runner.rb
@@ -58,7 +58,7 @@ module RubocopRunner
     end
   end
 
-  DEFAULT_ARGS = %w[--auto-correct
+  DEFAULT_ARGS = %w[--autocorrect
                     --format fuubar
                     --force-exclusion
                     --fail-level autocorrect].freeze

--- a/lib/rubocop_runner.rb
+++ b/lib/rubocop_runner.rb
@@ -58,7 +58,7 @@ module RubocopRunner
     end
   end
 
-  DEFAULT_ARGS = %w[--autocorrect
+  DEFAULT_ARGS = %w[-a
                     --format fuubar
                     --force-exclusion
                     --fail-level autocorrect].freeze

--- a/lib/rubocop_runner/version.rb
+++ b/lib/rubocop_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubocopRunner
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
Rubocop 1.30.0 deprecated `auto-correct` as an argument and changed to `autocorrect` (see https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md). This change updates the `rubocop_runner` default arguments to use the current value (i.e. `autocorrect`) to eliminate deprecation warnings when the pre-commit hook runs.