### PR TITLE
Fixes bug/inconvenience where the pre-commit hook changes the Gemfile.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,25 @@
-Changelog
-===
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-master
----
+## [Unreleased]
 
-2.2.0
----
+## [2.3.0] - 2022-10-06
+### Changed
+- Installed pre-commit hook does not need to load whole bundle anymore, which makes it faster to load
+- Pre-commit hook does not unexpectedly change your Gemfile.lock if you commit using another ruby platform on your shell then the one that was used to build the Gemfile.lock
 
+## [2.2.0] - ???
+### Changed
 - also inspect `.rake` files
 - readme format changes
 
-2.1.0
----
-
+## [2.1.0] - ???
+### Changed
 - package rake task within gem [#2](https://github.com/runtastic/rubocop_runner/pull/2)
 
-2.0.1
----
-
+## [2.0.1] - ???
+### Changed
 - initial open source release

--- a/lib/rubocop_runner.rb
+++ b/lib/rubocop_runner.rb
@@ -6,81 +6,16 @@ require 'rubocop'
 module RubocopRunner
   module_function
 
-  # from https://github.com/djberg96/ptools/blob/master/lib/ptools.rb#L90
-  def binary?(file)
-    return true if File.ftype(file) != 'file'
-
-    s = (File.read(file, File.stat(file).blksize) || '').split(//)
-    ((s.size - s.grep(' '..'~').size) / s.size.to_f) > 0.30
-  end
-
-  def staged_files
-    files = `git diff --cached --name-only --diff-filter=ACM`.split
-    files.reject do |f|
-      if File.ftype(f) != 'file'
-        true
-      else
-        size = File.size(f)
-        size > 1_000_000 || (size > 20 && binary?(f))
-      end
-    end
-  end
-
-  def merge?
-    File.exist?('.git/MERGE_MSG') && File.exist?('.git/MERGE_HEAD')
-  end
-
-  def conflict_files
-    IO.read('.git/MERGE_MSG')
-      .each_line
-      .select { |e| e.start_with?("\t") }
-      .map(&:strip)
-  end
-
-  def files
-    if merge?
-      conflict_files
-    else
-      staged_files
-    end
-  end
-
-  RUBY_PATTERN = /\.(rb|gemspec|rake)$/.freeze
-  RUBY_NAMES = %w[Guardfile Gemfile Rakefile config.ru].freeze
-
-  def ruby_file?(filename)
-    RUBY_NAMES.include?(filename) || !(filename =~ RUBY_PATTERN).nil?
-  end
-
-  def staged_ruby_files
-    @ruby_files ||= files.select do |file|
-      !File.directory?(file) && File.exist?(file) && ruby_file?(file)
-    end
-  end
-
-  DEFAULT_ARGS = %w[--auto-correct
-                    --format fuubar
-                    --force-exclusion
-                    --fail-level autocorrect].freeze
-  def run
-    return 0 if staged_ruby_files.empty?
-
-    ::RuboCop::CLI.new.run(DEFAULT_ARGS + staged_ruby_files)
-  end
-
-  RUBOCOP_RUNNER_HOME =
-    Pathname.new(File.join(File.dirname(__FILE__), '..')).realpath
-
-  def root
-    RUBOCOP_RUNNER_HOME
-  end
-
   def create_backup(pre_commit_path)
     return unless File.exist?(pre_commit_path)
 
     FileUtils.mv(pre_commit_path,
-                 pre_commit_path.join('.bkp'),
+                 "#{pre_commit_path}.bak",
                  force: true)
+  end
+  
+  def root
+    Pathname.new(File.join(File.dirname(__FILE__), '..')).realpath
   end
 
   def install(root = '.')

--- a/lib/rubocop_runner/version.rb
+++ b/lib/rubocop_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubocopRunner
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end

--- a/lib/template/pre-commit
+++ b/lib/template/pre-commit
@@ -1,12 +1,21 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
-begin
-  require 'bundler/setup'
-  require 'rubocop_runner'
-rescue LoadError
-  puts "can't find rubocop in current bundle"
-  exit 1
+ADDED_OR_MODIFIED = /A|AM|^M/.freeze
+FILE_EXTENSIONS = %w[.rb .ru].freeze
+FILES = %w[Guardfile Gemfile Rakefile]
+
+changed_files = `git status --porcelain`.split(/\n/).
+    select { |file_name_with_status|
+      file_name_with_status =~ ADDED_OR_MODIFIED
+    }.
+    map { |file_name_with_status|
+      file_name_with_status.split(' ')[1]
+    }.
+    select { |file_name|
+      FILE_EXTENSIONS.include?(File.extname(file_name)) ||
+        FILES.include?(file_name)
+    }.join(' ')
+
+unless changed_files.empty?
+  exit! system("bundle exec rubocop --fail-level A -a #{changed_files}")
 end
-
-exit RubocopRunner.run


### PR DESCRIPTION
Changes:
- Installed pre-commit hook does not need to load whole bundle anymore, which makes it faster to load
- Pre-commit hook does not unexpectedly change your Gemfile.lock if you commit using another ruby platform on your shell then the one that was used to build the Gemfile.lock